### PR TITLE
Add bounds checks to loops

### DIFF
--- a/xor.go
+++ b/xor.go
@@ -12,6 +12,9 @@ func Bytes(dst, a, b []byte) int {
 	if len(dst) < n {
 		n = len(dst)
 	}
+	_ = dst[n-1]
+	_ = a[n-1]
+	_ = b[n-1]
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] ^ b[i]
 	}
@@ -26,6 +29,8 @@ func Byte(dst, a []byte, b byte) int {
 	if len(dst) < n {
 		n = len(dst)
 	}
+	_ = dst[n-1]
+	_ = a[n-1]
 	for i := 0; i < n; i++ {
 		dst[i] = a[i] ^ b
 	}

--- a/xor_amd64.go
+++ b/xor_amd64.go
@@ -53,11 +53,17 @@ func xorBytesGeneric(dst, a, b []byte, n int) {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
 		aw := *(*[]uintptr)(unsafe.Pointer(&a))
 		bw := *(*[]uintptr)(unsafe.Pointer(&b))
+		_ = aw[w-1]
+		_ = bw[w-1]
+		_ = dw[w-1]
 		for i := 0; i < w; i++ {
 			dw[i] = aw[i] ^ bw[i]
 		}
 	}
 
+	_ = dst[n-1]
+	_ = a[n-1]
+	_ = b[n-1]
 	for i := (n - n%wordSize); i < n; i++ {
 		dst[i] = a[i] ^ b[i]
 	}
@@ -81,11 +87,15 @@ func Byte(dst, a []byte, b byte) int {
 	if w > 0 {
 		dw := *(*[]uintptr)(unsafe.Pointer(&dst))
 		aw := *(*[]uintptr)(unsafe.Pointer(&a))
+		_ = aw[w-1]
+		_ = dw[w-1]
 		for i := 0; i < w; i++ {
 			dw[i] = aw[i] ^ bw
 		}
 	}
 
+	_ = dst[n-1]
+	_ = a[n-1]
 	for i := (n - n%wordSize); i < n; i++ {
 		dst[i] = a[i] ^ b
 	}


### PR DESCRIPTION
I've had a lot of succes with this library on AMD64, but performance on WebAssembly is less stellar (no surprise there).

Toying around with `go build -gcflags="-d=ssa/check_bce/debug=1" .` indicated a number of bounds checks that could be eliminated.

I have no clue how to disable the assembly versions, but benchmarking showed some significant savings on `Byte()`.

This might help a lot on WebAssembly and other architectures.

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkBytes/16-8          7.69          7.33          -4.68%
BenchmarkBytes/1024-8        19.5          19.9          +2.05%
BenchmarkBytes/65k-8         1126          1122          -0.36%
BenchmarkRefBytes/16-8       20.0          20.7          +3.50%
BenchmarkRefBytes/1024-8     728           727           -0.14%
BenchmarkRefBytes/65k-8      45890         45773         -0.25%
BenchmarkByte/16-8           18.1          16.1          -11.05%
BenchmarkByte/1024-8         100           74.5          -25.50%
BenchmarkByte/65k-8          4857          3442          -29.13%
BenchmarkRefByte/16-8        18.9          18.9          +0.00%
BenchmarkRefByte/1024-8      1144          1158          +1.22%
BenchmarkRefByte/65k-8       73227         72125         -1.50%
BenchmarkBlock-8             0.32          0.28          -12.11%
BenchmarkRefBlock-8          9.66          9.41          -2.59%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkBytes/16-8          2081.43      2183.45      1.05x
BenchmarkBytes/1024-8        52424.01     51455.07     0.98x
BenchmarkBytes/65k-8         58210.15     58393.40     1.00x
BenchmarkRefBytes/16-8       799.44       774.16       0.97x
BenchmarkRefBytes/1024-8     1406.68      1409.17      1.00x
BenchmarkRefBytes/65k-8      1428.12      1431.77      1.00x
BenchmarkByte/16-8           881.99       996.64       1.13x
BenchmarkByte/1024-8         10219.16     13745.84     1.35x
BenchmarkByte/65k-8          13493.82     19040.22     1.41x
BenchmarkRefByte/16-8        848.56       845.38       1.00x
BenchmarkRefByte/1024-8      895.03       884.24       0.99x
BenchmarkRefByte/65k-8       894.97       908.64       1.02x
BenchmarkBlock-8             49728.77     56485.41     1.14x
BenchmarkRefBlock-8          1656.83      1700.97      1.03x
```